### PR TITLE
docker: remove redundant python installs

### DIFF
--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -1,12 +1,8 @@
 # common image to install CentOS7, updates, needed packages and NPM
 FROM centos:7
 
-RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm
 RUN yum install -y \
         yum-utils \
-        python36u \
-        python36u-devel \
-        python36u-pip \
         curl \
         git \
         rlwrap \


### PR DESCRIPTION
Closes inveniosoftware/docker-invenio#22

# Testing

- Python shell works (v3.6)
- Pip works
- Python devel package is present
- Used as base image for CERN Search docker image