### PR TITLE
Create files mountpoints

### DIFF
--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -47,6 +47,11 @@ ENV WORKING_DIR=/opt/invenio
 ENV INVENIO_INSTANCE_PATH=${WORKING_DIR}/var/instance
 RUN mkdir -p ${INVENIO_INSTANCE_PATH}
 
+# Create files mountpoints
+RUN mkdir ${INVENIO_INSTANCE_PATH}/data
+RUN mkdir ${INVENIO_INSTANCE_PATH}/archive
+RUN mkdir ${INVENIO_INSTANCE_PATH}/static
+
 # copy everything inside /src
 RUN mkdir -p ${WORKING_DIR}/src
 WORKDIR ${WORKING_DIR}/src

--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -56,6 +56,11 @@ ENV WORKING_DIR=/opt/invenio
 ENV INVENIO_INSTANCE_PATH=${WORKING_DIR}/var/instance
 RUN mkdir -p ${INVENIO_INSTANCE_PATH}
 
+# Create files mountpoints
+RUN mkdir ${INVENIO_INSTANCE_PATH}/data
+RUN mkdir ${INVENIO_INSTANCE_PATH}/archive
+RUN mkdir ${INVENIO_INSTANCE_PATH}/static
+
 # copy everything inside /src
 RUN mkdir -p ${WORKING_DIR}/src
 WORKDIR ${WORKING_DIR}/src


### PR DESCRIPTION
Mountpoints are created here to make sure
they have the right permissions.

The initially empty created volumes will then
copy those permissions when mounted.

See https://github.com/inveniosoftware/cookiecutter-invenio-instance/pull/168 .