### PR TITLE
Pin pipenv < 2020-05-28 to dispel error message

### DIFF
--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -34,7 +34,7 @@ ENV BASH_ENV=/etc/profile.d/enablepython36.sh
 RUN chmod -R g=u /etc/profile.d/enablepython36.sh /opt/rh/rh-python36 && \
     chgrp -R 0 /etc/profile.d/enablepython36.sh /opt/rh/rh-python36
 SHELL ["/bin/bash", "-c"]
-RUN pip --version && pip install --upgrade pip pipenv setuptools wheel
+RUN pip --version && pip install --upgrade pip 'pipenv<2020-05-28' setuptools wheel
 
 # set the locale
 RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8

--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -42,7 +42,7 @@ RUN alternatives --set python /usr/bin/python3.7
 
 # symlink pip
 RUN ln -s /usr/bin/python3/bin/pip3.7 /usr/bin/pip
-RUN pip install --upgrade pip pipenv setuptools wheel
+RUN pip install --upgrade pip 'pipenv<2020-05-28' setuptools wheel
 RUN ln -s /usr/bin/python3/bin/pipenv /usr/bin/pipenv
 
 # set the locale


### PR DESCRIPTION
Since pipenv==2020-05-28, using `pipenv install --system --deploy` results in an error message saying it can't find a virtualenv Python. Though not necessarily fatal, it is confusing, so let's revert to an older pipenv for now.

More background: pypa/pipenv#4315 and pypa/pipenv#4311.

Resolves #28.