### PR TITLE
Move to python:3.7-slim-buster for the 3.7 base image

### DIFF
--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -1,49 +1,30 @@
-# common image to install CentOS7, updates, needed packages and NPM
-FROM centos:7
+# common image to install Python 3.7 on Debian buster, updates, needed packages and NPM
+FROM python:3.7-slim-buster
 
-RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm
-RUN yum install -y \
-        yum-utils \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
         curl \
         git \
         rlwrap \
         screen \
         vim \
         gcc \
-        openssl-devel \
-        bzip2-devel \
-        emacs-nox && \
-    yum install -y \
-        epel-release && \
-    yum groupinstall -y "Development Tools" && \
-    yum install -y \
-        libffi-devel \
-        libxml2-devel \
-        libxslt-devel
+        emacs-nox \
+        libffi-dev \
+        libxml2-dev \
+        libxslt-dev \
+        libcairo-5c0 \
+        # For localedef
+        locales && \
+     apt-get clean
 
-RUN yum clean -y all
 
 # install nodejs version 10
-RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash - && \
-    yum install -y nodejs
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    apt-get clean
 
-# Download and install Python 3.7
-RUN curl https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tgz -O -J -L && \
-    tar xzf Python-3.7.0.tgz -C /usr/src/ && \
-    /usr/src/Python-3.7.0/configure --enable-optimizations --prefix=/usr/bin/python3 && \
-    make altinstall && \
-    ln -s /usr/bin/python3/bin/python3.7 /usr/bin/python3.7 && \
-    rm Python-3.7.0.tgz
-
-# set python3.7 as default
-RUN alternatives --install /usr/bin/python python /usr/bin/python2 50
-RUN alternatives --install /usr/bin/python python /usr/bin/python3.7 70
-RUN alternatives --set python /usr/bin/python3.7
-
-# symlink pip
-RUN ln -s /usr/bin/python3/bin/pip3.7 /usr/bin/pip
-RUN pip install --upgrade pip 'pipenv<2020-05-28' setuptools wheel
-RUN ln -s /usr/bin/python3/bin/pipenv /usr/bin/pipenv
+RUN pip install --upgrade pip 'pipenv<2020-05-28' setuptools wheel --no-cache-dir
 
 # set the locale
 RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8


### PR DESCRIPTION
Spurred on by a [conversation on Discord](https://discordapp.com/channels/692989811736182844/704629170470125578/720668999418904626), this is a test of moving to the official Python docker images, as they provide for Python 3.7 and 3.8, which isn't yet available from any CentOS release. I've chosen the Debian buster image over the alpine one because of https://pythonspeed.com/articles/alpine-docker-python/, at @egabancho's [suggestion](https://discordapp.com/channels/692989811736182844/704629170470125578/720703039559696953).

I've tested this by creating a new InvenioRDM instance using `invenio-cli`, changing the base image for the `Dockerfile`, updating the `python_requires` value in the `Pipfile` and then `pipenv lock`ing. The resulting image builds successfully and shows the homepage expected.

Summary of changes:

* Python 3.7 is the default for the base image, so we no longer need to install it and make it the default using alternatives

* Move from the .rpm node package to the .deb one

* Add --no-cache-dir to pip command, for a smaller image and because the cache has no benefit

* Remove some -devel packages. Debian doesn't seem to have equivalent -dev packages

* Add libcairo, as it's needed by cairocffi, via invenio-formatter

* Add locales, as its files are needed by localedef

* Remove the yum 'Development Tools' group, as there's no obvious equivalent in Debian

*Edit*:
Closes https://github.com/inveniosoftware/docker-invenio/issues/10