### PR TITLE
Re-pin pipenv to '<2020.5.28'

### DIFF
--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -34,7 +34,7 @@ ENV BASH_ENV=/etc/profile.d/enablepython36.sh
 RUN chmod -R g=u /etc/profile.d/enablepython36.sh /opt/rh/rh-python36 && \
     chgrp -R 0 /etc/profile.d/enablepython36.sh /opt/rh/rh-python36
 SHELL ["/bin/bash", "-c"]
-RUN pip --version && pip install --upgrade pip 'pipenv>=2020-6-2' setuptools wheel
+RUN pip --version && pip install --upgrade pip 'pipenv<2020.5.28' setuptools wheel
 
 # set the locale
 RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8

--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -58,7 +58,7 @@ ENV PATH=/usr/bin/python3/bin:$PATH
 
 # symlink pip
 RUN ln -s /usr/bin/python3/bin/pip3.7 /usr/bin/pip
-RUN pip --version && pip install --upgrade pip 'pipenv<2020-05-28' setuptools wheel
+RUN pip --version && pip install --upgrade pip 'pipenv<2020.5.28' setuptools wheel
 RUN ln -s /usr/bin/python3/bin/pipenv /usr/bin/pipenv
 
 # Create working directory

--- a/python3.8/Dockerfile
+++ b/python3.8/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash - && \
 # Symlink python
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
-RUN pip3 install --upgrade pip 'pipenv<2020-05-28' setuptools wheel
+RUN pip3 install --upgrade pip 'pipenv<2020.5.28' setuptools wheel
 
 # Create working directory
 ENV WORKING_DIR=/opt/invenio


### PR DESCRIPTION
pipenv currently emits a confusing error message when used with `--system`, so pin it to a version where this wasn't happening. A fix has been committed upstream in pypa/pipenv@cce026e but hasn't been released yet.

See #28 for the issue tracking this problem, including details of the error message. We'll need to unpin when a new release is available.

This even gets the version string right, unlike last time ;-).