### PR TITLE
Update README to also describe the Py 3.7 and Py 3.8 images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,31 @@
-# CentOS 7 with Python 3 for Invenio
+# CentOS with Python 3 for Invenio
 
 [![Build Status](https://travis-ci.org/inveniosoftware/docker-invenio.svg?branch=master)](https://travis-ci.org/inveniosoftware/docker-invenio) [![image](https://img.shields.io/docker/automated/inveniosoftware/centos7-python.svg)](https://hub.docker.com/r/inveniosoftware/centos7-python/) [![image](https://img.shields.io/docker/build/inveniosoftware/centos7-python.svg)](https://hub.docker.com/r/inveniosoftware/centos7-python/builds/)
 
-This image serves as base image for [Invenio](https://github.com/inveniosoftware/invenio) instances running on CentOS7. The purpose is to provide a base image that is usable in production environments like OpenShift.
+This image serves as base image for [Invenio](https://github.com/inveniosoftware/invenio) instances running on CentOS.
+The purpose is to provide a base image that is usable in production environments like OpenShift.
 
-The image is based on the official CentOS image ``centos:7`` and contains:
+The image is based on the official CentOS `centos:7` and `centos:8.2.2004` images and contains:
 
-- Python 3.6 set as default Python interpreter with upgraded versions of pip, pipenv, setuptools and wheel.
+- Python 3.6, 3.7 or 3.8 set as default Python interpreter with upgraded versions of pip, pipenv, setuptools and wheel.
 - Tools: Node.js, NPM, Git, Curl Vim, Emacs, Development Tools.
 - Library devel packages: libffi, libxml2, libxslt.
 - Working directory for an Invenio instance.
 
 ## Supported tags and respective ``Dockerfile`` links
 
-* 3.6 - [Dockerfile](https://github.com/inveniosoftware/docker-invenio/blob/master/python3.6/Dockerfile).
+| Tag | Python version | Base CentOS version | Dockerfile |
+| --- | -------------- | ------------------- | ---------- |
+| [inveniosoftware/centos7-python:3.6]( https://hub.docker.com/r/inveniosoftware/centos7-python) | 3.6 | 7        | [python3.6/Dockerfile](https://github.com/inveniosoftware/docker-invenio/blob/master/python3.6/Dockerfile) |
+| [inveniosoftware/centos8-python:3.7]( https://hub.docker.com/r/inveniosoftware/centos8-python) | 3.7 | 8.2.2004 | [python3.7/Dockerfile](https://github.com/inveniosoftware/docker-invenio/blob/master/python3.7/Dockerfile) |
+| [inveniosoftware/centos8-python:3.8]( https://hub.docker.com/r/inveniosoftware/centos8-python) | 3.8 | 8.2.2004 | [python3.8/Dockerfile](https://github.com/inveniosoftware/docker-invenio/blob/master/python3.8/Dockerfile) |
+
 
 ## Usage
 
-This image is used by the scaffolded Dockerfile in the Invenio [getting started guide](https://inveniosoftware.org/gettingstarted/). See the guide for quickly getting started.
+This image is used by the scaffolded Dockerfile in the Invenio [getting started
+guide](https://inveniosoftware.org/gettingstarted/). See the guide for quickly getting started.
+
 
 ### Create a ``Dockerfile``
 
@@ -40,11 +48,13 @@ The following environment variables has been set:
 
 ### Rolling builds
 
-The image is rebuild when the base image ``centos7:latest`` is updated.  The base image is receiving regular monthly updates as well as emergency fixes.
+The 3.6 image is rebuilt when the base image ``centos7:latest`` is updated.  The base image is receiving regular monthly
+updates as well as emergency fixes.
 
 ## Automated builds
 
-Automated builds are configured using [Docker Hub builds](https://docs.docker.com/docker-hub/builds/). The triggers are defined the following way:
+Automated builds are configured using [Docker Hub builds](https://docs.docker.com/docker-hub/builds/). The triggers are
+defined the following way:
 
 ```(bash)
 Branch/tag               Dockerfile                Docker tag
@@ -53,7 +63,8 @@ Push to master     ---> /python3.6/Dockerfile ---> 3.6
 Push /^3\.6.*/ tag ---> /python3.6/Dockerfile ---> git-tag-name, 3.6
 ```
 
-This way, we will use tag `3.6` as latest for Python version and there is also the possibility to push tags for specific use cases such as pinning certain libraries or patches.
+This way, we will use tag `3.6` as latest for Python version and there is also the possibility to push tags for specific
+use cases such as pinning certain libraries or patches.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,23 +48,13 @@ The following environment variables has been set:
 
 ### Rolling builds
 
-The 3.6 image is rebuilt when the base image ``centos7:latest`` is updated.  The base image is receiving regular monthly
+The images are rebuilt when the base images are updated.  The base image are receiving regular monthly
 updates as well as emergency fixes.
 
 ## Automated builds
 
-Automated builds are configured using [Docker Hub builds](https://docs.docker.com/docker-hub/builds/). The triggers are
-defined the following way:
-
-```(bash)
-Branch/tag               Dockerfile                Docker tag
-
-Push to master     ---> /python3.6/Dockerfile ---> 3.6
-Push /^3\.6.*/ tag ---> /python3.6/Dockerfile ---> git-tag-name, 3.6
-```
-
-This way, we will use tag `3.6` as latest for Python version and there is also the possibility to push tags for specific
-use cases such as pinning certain libraries or patches.
+Automated builds are configured using [Docker Hub builds](https://docs.docker.com/docker-hub/builds/), with each
+push to master initating a Docker Hub build that will be tagged per the table above.
 
 ## License
 


### PR DESCRIPTION
I don't know whether the non-3.6 images have automated builds, so I've leftthat section alone, making sure it only refers to Py 3.6.

Resolves #33.