### PR TITLE
global: add dejavu fonts for invenio-formatter badges

### DIFF
--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -20,6 +20,7 @@ RUN yum install -y \
     yum groupinstall -y "Development Tools" && \
     yum install -y \
         cairo-devel \
+        dejavu-sans-fonts \
         libffi-devel \
         libxml2-devel \
         libxslt-devel
@@ -40,7 +41,7 @@ ENV BASH_ENV=/etc/profile.d/enablepython36.sh
 RUN chmod -R g=u /etc/profile.d/enablepython36.sh /opt/rh/rh-python36 && \
     chgrp -R 0 /etc/profile.d/enablepython36.sh /opt/rh/rh-python36
 SHELL ["/bin/bash", "-c"]
-RUN pip --version && pip install --upgrade pip 'pipenv<2020.5.28' setuptools wheel
+RUN pip --version && pip install --upgrade pip pipenv setuptools wheel
 
 # set the locale
 RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8

--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -43,8 +43,11 @@ RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash - && \
     yum install -y nodejs
 
 # Download and install Python 3.7
+# Need to remove symlink from /usr/bin/python3 -> /usr/bin/python3.6
+# so alinstall does not fail
 RUN curl https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tgz -O -J -L && \
     tar xzf Python-3.7.0.tgz -C /usr/src/ && \
+    rm -f /usr/bin/python3 && \
     /usr/src/Python-3.7.0/configure --enable-optimizations --prefix=/usr/bin/python3 && \
     make altinstall && \
     ln -s /usr/bin/python3/bin/python3.7 /usr/bin/python3.7 && \

--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -30,6 +30,7 @@ RUN yum install -y \
     yum groupinstall -y "Development Tools" && \
     yum install -y \
         cairo-devel \
+        dejavu-sans-fonts \
         libffi-devel \
         libxml2-devel \
         libxslt-devel \
@@ -58,7 +59,7 @@ ENV PATH=/usr/bin/python3/bin:$PATH
 
 # symlink pip
 RUN ln -s /usr/bin/python3/bin/pip3.7 /usr/bin/pip
-RUN pip --version && pip install --upgrade pip 'pipenv<2020.5.28' setuptools wheel
+RUN pip --version && pip install --upgrade pip pipenv setuptools wheel
 RUN ln -s /usr/bin/python3/bin/pipenv /usr/bin/pipenv
 
 # Create working directory

--- a/python3.8/Dockerfile
+++ b/python3.8/Dockerfile
@@ -23,6 +23,7 @@ RUN yum install -y \
     yum groupinstall -y "Development Tools" && \
     yum install -y \
         cairo-devel \
+        dejavu-sans-fonts \
         libffi-devel \
         libxml2-devel \
         libxslt-devel
@@ -36,7 +37,7 @@ RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash - && \
 # Symlink python
 RUN ln -s /usr/bin/python3 /usr/bin/python
 
-RUN pip3 install --upgrade pip 'pipenv<2020.5.28' setuptools wheel
+RUN pip3 install --upgrade pip pipenv setuptools wheel
 
 # Create working directory
 ENV WORKING_DIR=/opt/invenio

--- a/python3.8/Dockerfile
+++ b/python3.8/Dockerfile
@@ -35,7 +35,7 @@ RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash - && \
     yum install -y nodejs
 
 # Symlink python
-RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN ln -s /usr/bin/python3.8 /usr/bin/python
 
 RUN pip3 install --upgrade pip pipenv setuptools wheel
 


### PR DESCRIPTION
closes inveniosoftware/invenio-formatter#81
closes #35 

Tested **only the image for Python3.7** by deploying (locally) and InvenioRDM instance which works (i.e. demo records + publish a record with a DOI).

Python3.6 and 3.8 images are only tested by the CI (i.e. python -V works and gives a correct version)