### PR TITLE
global: change base to 8 for python 3.7 and 3.8, add locales

### DIFF
--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -1,10 +1,11 @@
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2021 CERN.
+# Copyright (C) 2021 TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 #
-ARG CENTOS_VERSION=7
+ARG CENTOS_VERSION=8
 FROM centos:${CENTOS_VERSION}
 
 

--- a/python3.8/Dockerfile
+++ b/python3.8/Dockerfile
@@ -1,12 +1,21 @@
 #
 # Copyright (C) 2018-2020 CERN.
 # Copyright (C) 2020 Cottage Labs LLP.
+# Copyright (C) 2021 TU Wien.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 #
-ARG CENTOS_VERSION=7
+ARG CENTOS_VERSION=8
 FROM centos:${CENTOS_VERSION}
+
+# set the locale
+# avoid Failed to set locale, defaulting to C.UTF-8
+RUN yum install -y glibc-locale-source
+RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
 
 RUN yum install -y \
         yum-utils \


### PR DESCRIPTION
replaces https://github.com/inveniosoftware/docker-invenio/pull/41

- Python 3.6: existing locales, due to `glibc-common` and they are set in line 46

 ```
 [root@6615771020cb src]# yum list installed | grep glibc
glibc.x86_64                         2.17-324.el7_9              @updates
glibc-common.x86_64                  2.17-324.el7_9              @updates
glibc-devel.x86_64                   2.17-324.el7_9              @updates
glibc-headers.x86_64                 2.17-324.el7_9              @updates
[root@6615771020cb src]# echo $LC_ALL
en_US.UTF-8
[root@6615771020cb src]# echo $LANGUAGE
en_US:en
[root@6615771020cb src]# echo $LANG
en_US.UTF-8
```

- Python 3.7 were being set explicitly at first
- Python 3.8 added in this PR