### PR TITLE
dependencies: pin setuptools

### DIFF
--- a/python3.6/Dockerfile
+++ b/python3.6/Dockerfile
@@ -42,7 +42,10 @@ ENV BASH_ENV=/etc/profile.d/enablepython36.sh
 RUN chmod -R g=u /etc/profile.d/enablepython36.sh /opt/rh/rh-python36 && \
     chgrp -R 0 /etc/profile.d/enablepython36.sh /opt/rh/rh-python36
 SHELL ["/bin/bash", "-c"]
-RUN pip --version && pip install --upgrade pip pipenv setuptools wheel
+
+# setuptools v58 removed 2to3 support: https://setuptools.pypa.io/en/latest/history.html#v58-0-0
+# the `fs` package relies on `2to3`
+RUN pip --version && pip install --upgrade pip pipenv "setuptools<58" wheel
 
 # set the locale
 RUN localedef --quiet -c -i en_US -f UTF-8 en_US.UTF-8

--- a/python3.7/Dockerfile
+++ b/python3.7/Dockerfile
@@ -64,7 +64,10 @@ ENV PATH=/usr/bin/python3/bin:$PATH
 
 # symlink pip
 RUN ln -s /usr/bin/python3/bin/pip3.7 /usr/bin/pip
-RUN pip --version && pip install --upgrade pip pipenv setuptools wheel
+
+# setuptools v58 removed 2to3 support: https://setuptools.pypa.io/en/latest/history.html#v58-0-0
+# the `fs` package relies on `2to3`
+RUN pip --version && pip install --upgrade pip pipenv "setuptools<58" wheel
 RUN ln -s /usr/bin/python3/bin/pipenv /usr/bin/pipenv
 
 # Create working directory

--- a/python3.8/Dockerfile
+++ b/python3.8/Dockerfile
@@ -51,7 +51,9 @@ RUN ln -sfn /usr/bin/python3.8 /usr/bin/python3 & \
     ln -sfn /usr/bin/pip3.8 /usr/bin/pip3 & \
     ln -sfn /usr/bin/pip3 /usr/bin/pip
 
-RUN pip3 install --upgrade pip pipenv setuptools wheel
+# setuptools v58 removed 2to3 support: https://setuptools.pypa.io/en/latest/history.html#v58-0-0
+# the `fs` package relies on `2to3`
+RUN pip3 install --upgrade pip pipenv "setuptools<58" wheel
 
 # Create working directory
 ENV WORKING_DIR=/opt/invenio


### PR DESCRIPTION
* the release of setuptools v58 dropped support for 2to3
* the `fs` packages used by Invenio still needs 2to3