### PR TITLE
Add GitHub Action to build Docker Image with AlmaLinux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/almalinux
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+          flavor: |
+            latest=true
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.1.0
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2.1.0 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push to GitHub Packages
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: ./python3.9/almalinux9/
+          file: ./python3.9/almalinux9/Dockerfile
+          # support images for Intel and Apple Silicon processors
+          platforms: linux/amd64, linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          

--- a/python3.9/almalinux9/Dockerfile
+++ b/python3.9/almalinux9/Dockerfile
@@ -7,7 +7,7 @@
 # under the terms of the MIT License; see LICENSE file for more details.
 #
 ARG LINUX_VERSION=9.0
-FROM almalinux:${LINUX_VERSION}
+FROM --platform=$BUILDPLATFORM almalinux:${LINUX_VERSION}
 
 RUN dnf upgrade --refresh -y && \
     dnf install -y \


### PR DESCRIPTION
### Description

Using the GitHub Actions `docker/metadata-action`, `docker/setup-buildx-action`, `docker/login-action`, and `docker/build-push-action`. Pushing the built Docker image to GitHub Package Registry.

More work is needed to update the ReadMe and decide about the build matrix (e.g. do we want to support building CentOS7 images), and deciding about the included node version (probably node 18).

Building the Docker image in two formats: `linux/amd64` and `linux/arm64` (the latter is needed to run containers natively on Apple Silicon hardware).

Addresses #51.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/best-practices/i18n/) (for relevant code).
- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines (for relevant code).
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines (for relevant code).
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines (for relevant code).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).