### PR TITLE
Remove "npm prefix" test

### DIFF
--- a/tests/test_image_python.sh
+++ b/tests/test_image_python.sh
@@ -21,8 +21,14 @@ if ! hash pip; then
     exit 1
 fi
 
-if [ $(npm config get prefix) != '/opt/invenio/var/instance/.npm-global' ]; then
-    echo "Image does not have the correct npm prefix configured."
+if ! hash node; then
+    echo "Image does not have node installed."
+    echo 1 >> /tmp/tests_output.txt
+    exit 1
+fi
+
+if ! hash npm; then
+    echo "Image does not have npm installed."
     echo 1 >> /tmp/tests_output.txt
     exit 1
 fi


### PR DESCRIPTION
This PR removes the test which checked if the `npm prefix` was set to `${INVENIO_INSTANCE_PATH}/.npm-global`, which if I understood correctly, was only a convention.

If instead we want to keep it, we may need to troubleshoot why `nvm` whines about it. See: https://stackoverflow.com/questions/34718528/nvm-is-not-compatible-with-the-npm-config-prefix-option