### PR TITLE
deps: add libpq-devel

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,12 @@ FROM registry.cern.ch/inveniosoftware/almalinux:latest
 
 The images are rebuilt when the base images are updated. The base image are receiving regular monthly
 updates as well as emergency fixes.
+
+### Local builds
+
+To test the Dockerimage locally, you can build it by doing:
+
+```
+cd almalinux
+docker build . -t almalinux:1
+```

--- a/almalinux/Dockerfile
+++ b/almalinux/Dockerfile
@@ -36,6 +36,7 @@ RUN dnf groupinstall -y "Development Tools" && \
         cairo-devel \
         dejavu-sans-fonts \
         libffi-devel \
+        libpq-devel \
         libxml2-devel \
         libxslt-devel \
         ImageMagick \


### PR DESCRIPTION
* add libpq-devel to the installed dependencies, needed for invenio-rdm-migrator.