### PR TITLE
Fixed NodeJS 16 install for Almalinux Dockerfile

### DIFF
--- a/almalinux/Dockerfile
+++ b/almalinux/Dockerfile
@@ -54,8 +54,14 @@ RUN yum remove python3-packaging -y
 RUN pip3 install --upgrade pip pipenv wheel
 
 # Install Node.js v16
-RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
-    yum install -y nodejs
+
+## The Node 16 package is signed using SHA1, which is deprecated on Almalinux 9. 
+## We change the policy to allow it.
+RUN update-crypto-policies --set DEFAULT:SHA1 &&\
+    curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
+    yum install -y nodejs && \
+    ## We restore the default policy
+    update-crypto-policies --set DEFAULT
 
 # Create working directory
 ENV WORKING_DIR=/opt/invenio


### PR DESCRIPTION
The NodeJS 16 package is signed using SHA1, which is deprecated in Almalinux/RHEL 9 [1] and the build fails with an error such as:

```
19.04 Importing GPG key 0x9B1BE0B4:
19.04  Userid     : "NSolid <nsolid-gpg@nodesource.com>"
19.04  Fingerprint: 6F71 F525 2828 41EE DAF8 51B4 2F59 B5F9 9B1B E0B4
19.04  From       : https://rpm.nodesource.com/gpgkey/NODESOURCE-GPG-SIGNING-KEY-EL
19.04 warning: Signature not supported. Hash algorithm SHA1 not available.
19.04 Key import failed (code 2). Failing package is: nodejs-2:16.20.2-1nodesource.x86_64
19.04  GPG Keys are configured as: https://rpm.nodesource.com/gpgkey/NODESOURCE-GPG-SIGNING-KEY-EL
19.04 The downloaded packages were saved in cache until the next successful transaction.
19.04 You can remove cached packages by executing 'yum clean packages'.
19.06 Error: GPG check FAILED
------

 3 warnings found (use --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 24)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 25)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 26)
Dockerfile:59
--------------------
  58 |     # Install Node.js v16
  59 | >>> RUN curl -fsSL https://rpm.nodesource.com/setup_16.x | bash - && \
  60 | >>>     yum install -y nodejs
  61 |     
--------------------
```

I fixed the problem by temporarily allowing SHA1 signatures.

[1] https://www.redhat.com/en/blog/rhel-security-sha-1-package-signatures-distrusted-rhel-9