### PR TITLE
Add useful tools and optmize image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Invenio docker images
+# Invenio Docker images
 
 [![Build Status](https://github.com/inveniosoftware/docker-invenio/workflows/CI/badge.svg)](https://github.com/inveniosoftware/docker-invenio/actions)
 
@@ -12,7 +12,7 @@ Previous images, still available in this repository for reference only, were bas
 The [current image](almalinux/Dockerfile) is based on the AlmaLinux version 9 and contains:
 
 - Python v3.9 set as default Python interpreter with upgraded versions of pip, pipenv, setuptools and wheel.
-- Node.js v16.x
+- Node.js v20.x
 - Working directory for an Invenio instance.
 
 Images are currently published in the CERN registry `registry.cern.ch`.
@@ -34,9 +34,14 @@ updates as well as emergency fixes.
 
 ### Local builds
 
-To test the Dockerimage locally, you can build it by doing:
+To test the Dockerimage locally, you can build it and run it by doing:
 
 ```
 cd almalinux
 docker build . -t almalinux:1
+docker run -it almalinux:1 /bin/bash
 ```
+
+## Optimization
+
+You can use a tool like [dive](https://github.com/wagoodman/dive) to explore the layers of the Docker images and optimize it.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Previous images, still available in this repository for reference only, were bas
 The [current image](almalinux/Dockerfile) is based on the AlmaLinux version 9 and contains:
 
 - Python v3.9 set as default Python interpreter with upgraded versions of pip, pipenv, setuptools and wheel.
-- Node.js v20.x
+- Node.js v22.x
 - Working directory for an Invenio instance.
 
 Images are currently published in the CERN registry `registry.cern.ch`.

--- a/almalinux/Dockerfile
+++ b/almalinux/Dockerfile
@@ -66,8 +66,8 @@ RUN ln -sfn /usr/bin/python3 /usr/bin/python
 RUN yum remove python3-packaging -y
 RUN pip3 install --upgrade pip pipenv wheel
 
-# Install Node.js v20
-RUN curl -fsSL https://rpm.nodesource.com/setup_20.x | bash - && \
+# Install Node.js
+RUN curl -fsSL https://rpm.nodesource.com/setup_22.x | bash - && \
     dnf -y install nodejs
 
 # Reduce image size: clean up caches, remove RPM db files

--- a/almalinux/Dockerfile
+++ b/almalinux/Dockerfile
@@ -17,21 +17,30 @@ RUN dnf upgrade --refresh -y && \
         git \
         glibc-common \
         glibc-locale-source \
-        glibc-langpack-en
+        glibc-langpack-en \
+        gcc
 
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US:en
-ENV LC_ALL en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
 
-# crb is needed to install epel, epel contains ImageMagick
+# EPEL: Extra Packages for Enterprise Linux 9
+# `epel-release` is not recent/complete enough, as some packages below are missing
 RUN dnf config-manager --set-enabled crb && \
     dnf install -y \
         https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 
-RUN dnf groupinstall -y "Development Tools" && \
-    dnf install -y \
+# Install needed and useful tools:
+#  - python and friends
+#  - basic system tools (procps-ng, htop, less, git, glibc, wget, curl)
+#  - process/file inspection tools (strace, lsof, file)
+#  - performance monitoring tools (iotop, iftop)
+#  - networking tools (tcpdump, bind-utils)
+# The installation of "Development Tools" should not be required. Be aware of its
+# size ~1.1 Gb
+RUN dnf install -y \
         pip \
         python3-devel \
         cairo-devel \
@@ -45,7 +54,11 @@ RUN dnf groupinstall -y "Development Tools" && \
         bzip2-devel \
         xz-devel \
         sqlite-devel \
-        xmlsec1-devel
+        xmlsec1-devel \
+        procps-ng htop less \
+        strace lsof file \
+        iotop iftop \
+        tcpdump bind-utils
 
 # Symlink Python
 RUN ln -sfn /usr/bin/python3 /usr/bin/python
@@ -57,21 +70,32 @@ RUN pip3 install --upgrade pip pipenv wheel
 RUN curl -fsSL https://rpm.nodesource.com/setup_20.x | bash - && \
     dnf -y install nodejs
 
+# Reduce image size: clean up caches, remove RPM db files
+RUN dnf clean all && \
+    rm -rf \
+        /var/cache/dnf \
+        /var/lib/rpm/__db* \
+        /var/lib/rpm/rpmdb.sqlite \
+        /var/lib/rpm/Packages
+
 # Create working directory
 ENV WORKING_DIR=/opt/invenio
 ENV INVENIO_INSTANCE_PATH=${WORKING_DIR}/var/instance
 
 # Create files mountpoints
-RUN mkdir -p ${INVENIO_INSTANCE_PATH} && \
-    mkdir ${INVENIO_INSTANCE_PATH}/data ${INVENIO_INSTANCE_PATH}/archive ${INVENIO_INSTANCE_PATH}/static
+RUN mkdir -p ${WORKING_DIR}/src && \
+    mkdir -p ${INVENIO_INSTANCE_PATH} && \
+    mkdir \
+        ${INVENIO_INSTANCE_PATH}/data \
+        ${INVENIO_INSTANCE_PATH}/archive \
+        ${INVENIO_INSTANCE_PATH}/static
 
-# copy everything inside /src
-RUN mkdir -p ${WORKING_DIR}/src
+# Invenio file will be in <WORKING_DIR>/src
 WORKDIR ${WORKING_DIR}/src
 
 # Set folder permissions
 ENV INVENIO_USER_ID=1000
 RUN chgrp -R 0 ${WORKING_DIR} && \
-    chmod -R g=u ${WORKING_DIR}
-RUN useradd invenio --uid ${INVENIO_USER_ID} --gid 0 && \
+    chmod -R g=u ${WORKING_DIR} && \
+    useradd invenio --uid ${INVENIO_USER_ID} --gid 0 && \
     chown -R invenio:root ${WORKING_DIR}


### PR DESCRIPTION
Should pass when https://github.com/inveniosoftware/docker-invenio/pull/84 is merged.

Adds a few tools to the image like `ps`, `top`, `less` , `wget` and network/file stats.

It also changes the Docker layers to improve optimization.
Removes `Development tools`, which looks unused. This reduces the total image size.

Before:
`Total Image size: 2.0 GB`

After:
![Screenshot 2024-12-02 at 18 33 34](https://github.com/user-attachments/assets/f497f918-4639-4343-a35f-9f8a9f939205)

In any case, to reduce the final Docker image size, we should take advantage of multi-stage build as much as possible in [the final app image](https://github.com/inveniosoftware/cookiecutter-invenio-rdm/blob/master/%7B%7Bcookiecutter.project_shortname%7D%7D/Dockerfile) (not here).